### PR TITLE
Use base reporter: support running as one of many reporters (Fix #1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var os = require('os');
 
-var LongestReporter = function (helper, longestSpecsToReport) {
+var LongestReporter = function (baseReporterDecorator, helper, longestSpecsToReport) {
+    baseReporterDecorator(this);
+
     var write = process.stdout.write.bind(process.stdout);
     var longestSpecsToReport = longestSpecsToReport ? longestSpecsToReport : 10;
     var specs = [];
@@ -28,7 +30,7 @@ var LongestReporter = function (helper, longestSpecsToReport) {
     }
 }
 
-LongestReporter.$inject = [ 'helper', 'config.longestSpecsToReport' ];
+LongestReporter.$inject = [ 'baseReporterDecorator', 'helper', 'config.longestSpecsToReport' ];
 
 module.exports = {
     'reporter:longest': [ 'type', LongestReporter ]


### PR DESCRIPTION
using baseReporterDecorator adds (among others) a capability to accept
adapters.

applied factory is defined here:
https://github.com/karma-runner/karma/blob/79bc193b02755424000b26ac9779d4c8716ccecc/lib/reporters/base.js#L139

Fix #1 